### PR TITLE
Add explicit checkout step to CI pipeline

### DIFF
--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -15,6 +15,9 @@ stages:
       - job: Validate
         displayName: Validate Terraform
         steps:
+          - checkout: self
+            clean: true
+            persistCredentials: true
           - script: |
               brew install tflint
               brew install checkov


### PR DESCRIPTION
- Fixes git tagging step that was failing by persisting git credentials across the pipeline