### PR TITLE
Extend wrapper templates for CI and CD pipeline

### DIFF
--- a/infrastructure/container-registry.tf
+++ b/infrastructure/container-registry.tf
@@ -1,8 +1,9 @@
 resource "azurerm_container_registry" "acr" {
-  name                = "pinscr${replace(local.resource_suffix, "-", "")}"
-  resource_group_name = azurerm_resource_group.tooling.name
-  location            = azurerm_resource_group.tooling.location
-  sku                 = "Premium"
+  name                          = "pinscr${replace(local.resource_suffix, "-", "")}"
+  resource_group_name           = azurerm_resource_group.tooling.name
+  location                      = azurerm_resource_group.tooling.location
+  public_network_access_enabled = false
+  sku                           = "Premium"
 
   georeplications {
     location = module.azure_region_secondary.location

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -1,9 +1,3 @@
-parameters:
-  - name: environments
-    type: object
-    default:
-      - name: Tooling
-
 trigger: none
 
 pr: none
@@ -38,7 +32,8 @@ extends:
             parameters:
               subscriptionId: $(SUBSCRIPTION_ID)
         isDeployment: true
-    environments: ${{ parameters.environments }}
+    environments:
+      - name: Tooling
     globalVariables:
       SUBSCRIPTION_ID: edb1ff78-90da-4901-a497-7e79f966f8e2
     project: infrastructure

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -35,5 +35,6 @@ extends:
     environments:
       - name: Tooling
     globalVariables:
-      SUBSCRIPTION_ID: edb1ff78-90da-4901-a497-7e79f966f8e2
+      - name: SUBSCRIPTION_ID
+        value: edb1ff78-90da-4901-a497-7e79f966f8e2
     project: infrastructure

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: environments
+    type: object
+    default:
+      - name: Tooling
+
 trigger: none
 
 pr: none
@@ -12,78 +18,27 @@ resources:
 pool:
   vmImage: ubuntu-latest
 
-variables:
-  SUBSCRIPTION_ID: edb1ff78-90da-4901-a497-7e79f966f8e2
-
-stages:
-  - stage: Plan
-    displayName: Terraform Plan
-    jobs:
-      - job: Plan
-        displayName: Terraform Plan
-        steps:
-          - task: AzureCLI@2
-            displayName: Azure Authentication
-            inputs:
-              scriptType: bash
-              scriptLocation: inlineScript
-              azureSubscription: Terraform Tooling
-              addSpnToEnvironment: true
-              inlineScript: |
-                echo "##vso[task.setvariable variable=azureClientId]$servicePrincipalId"
-                echo "##vso[task.setvariable variable=azureClientSecret]$servicePrincipalKey"
-                echo "##vso[task.setvariable variable=azureTenantId]$tenantId"
-          - script: |
-              terraform init -input=false
-              terraform plan -out=tfplan -input=false
-            displayName: Terraform Plan
-            env:
-              ARM_CLIENT_ID: $(azureClientId)
-              ARM_CLIENT_SECRET: $(azureClientSecret)
-              ARM_SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
-              ARM_TENANT_ID: $(azureTenantId)
-            workingDirectory: $(Build.Repository.LocalPath)/infrastructure
-          - task: CopyFiles@2
-            displayName: Copy tfplan to artifact
-            inputs:
-              SourceFolder: $(Build.Repository.LocalPath)/infrastructure
-              Contents: |
-                .terraform/**
-                .terraform.lock.hcl
-                tfplan
-              TargetFolder: $(Build.ArtifactStagingDirectory)
-          - publish: $(Build.ArtifactStagingDirectory)
-            artifact: terraform-plan
-            displayName: Publish sources
-  - stage: Apply
-    dependsOn: Plan
-    displayName: Terraform Apply
-    jobs:
-      - deployment: Apply
-        displayName: Terraform Apply
-        environment: Tooling
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - task: AzureCLI@2
-                  displayName: Azure Authentication
-                  inputs:
-                    scriptType: bash
-                    scriptLocation: inlineScript
-                    azureSubscription: Terraform Tooling
-                    addSpnToEnvironment: true
-                    inlineScript: |
-                      echo "##vso[task.setvariable variable=azureClientId]$servicePrincipalId"
-                      echo "##vso[task.setvariable variable=azureClientSecret]$servicePrincipalKey"
-                      echo "##vso[task.setvariable variable=azureTenantId]$tenantId"
-                - script: |
-                    chmod -R +x .
-                    terraform apply -input=false tfplan
-                  displayName: Terraform Apply
-                  env:
-                    ARM_CLIENT_ID: $(azureClientId)
-                    ARM_CLIENT_SECRET: $(azureClientSecret)
-                    ARM_SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
-                    ARM_TENANT_ID: $(azureTenantId)
-                  workingDirectory: $(Pipeline.Workspace)/terraform-plan
+extends:
+  template: stages/wrapper_cd.yml@templates
+  parameters:
+    deploymentStages:
+      - name: Terraform Plan
+        azureLogin: true
+        deploymentSteps:
+          - template: ${{variables['Build.SourcesDirectory']}}/steps/terraform_plan.yml@templates
+            parameters:
+              subscriptionId: $(SUBSCRIPTION_ID)
+              workingDirectory: $(Build.Repository.LocalPath)/infrastructure
+        isDeployment: false
+      - name: Terraform Apply
+        dependsOn:
+          - Terraform Plan
+        deploymentSteps:
+          - template: ${{variables['Build.SourcesDirectory']}}/steps/terraform_apply.yml@templates
+            parameters:
+              subscriptionId: $(SUBSCRIPTION_ID)
+        isDeployment: true
+    environments: ${{ parameters.environments }}
+    globalVariables:
+      SUBSCRIPTION_ID: edb1ff78-90da-4901-a497-7e79f966f8e2
+    project: infrastructure

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -8,26 +8,22 @@ resources:
 pool:
   vmImage: ubuntu-latest
 
-stages:
-  - stage: Validate
-    displayName: Validate Terraform
-    jobs:
-      - job: Validate
-        displayName: Validate Terraform
-        steps:
-          - checkout: self
-            clean: true
-            persistCredentials: true
-          - script: |
-              brew install tflint
-              brew install checkov
-            displayName: Install dependencies
-          - template: steps/terraform_format.yml@templates
-          - template: steps/terraform_tflint.yml@templates
-          - template: steps/run_checkov.yml@templates
-          - template: steps/terraform_validate.yml@templates
-            parameters:
-              workingDirectory: $(Build.Repository.LocalPath)/infrastructure
-          - template: steps/git_tagging.yml@templates
-            parameters:
-              tagPrefix: infrastructure-tooling
+extends:
+  template: stages/wrapper_ci.yml@templates
+  parameters:
+    project: infrastructure
+    validateName: Validate Terraform
+    validationSteps:
+      - script: |
+          brew install tflint
+          brew install checkov
+        displayName: Install dependencies
+      - template: steps/terraform_format.yml@templates
+      - template: steps/terraform_tflint.yml@templates
+      - template: steps/run_checkov.yml@templates
+      - template: steps/terraform_validate.yml@templates
+        parameters:
+          workingDirectory: $(Build.Repository.LocalPath)/infrastructure
+      - template: steps/git_tagging.yml@templates
+        parameters:
+          tagPrefix: infrastructure-tooling


### PR DESCRIPTION
- Use templates from common templates repo for CI and CD pipelines
- Checkov flagged that the Container Registry should have public access disabled, so have done so. Will see if this is a requirement later when we need to push/pull containers