### PR TITLE
Add outputs from container registry

### DIFF
--- a/infrastructure/cloud-shell.tf
+++ b/infrastructure/cloud-shell.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "cloud_shell" {
+  #TODO: Customer Managed Keys
+  #checkov:skip=CKV_AZURE_3: Secure transfer not required
+  #checkov:skip=CKV_AZURE_33: Logging not required for Cloud Shell
+  #checkov:skip=CKV_AZURE_35: Cloud Shell requires access
+  #checkov:skip=CKV2_AZURE_1: Customer Managed Keys not implemented yet
+  #checkov:skip=CKV2_AZURE_18: Customer Managed Keys not implemented yet
+  name                     = "pinsstsharedshelluks"
+  resource_group_name      = azurerm_resource_group.tooling.name
+  location                 = azurerm_resource_group.tooling.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+
+  tags = local.tags
+}

--- a/infrastructure/container-registry.tf
+++ b/infrastructure/container-registry.tf
@@ -1,8 +1,10 @@
 resource "azurerm_container_registry" "acr" {
+  #checkov:skip=CKV_AZURE_137: Admin account required so App services can pull containers when updated by pipeline
   #checkov:skip=CKV_AZURE_139: Access over internet required so Azure DevOps can push/pull images
   name                = "pinscr${replace(local.resource_suffix, "-", "")}"
   resource_group_name = azurerm_resource_group.tooling.name
   location            = azurerm_resource_group.tooling.location
+  admin_enabled       = true
   sku                 = "Premium"
 
   georeplications {

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,0 +1,17 @@
+output "acr_server_password" {
+  description = "The admin password used to connect to the Container Registry"
+  sensitive   = true
+  value       = azurerm_container_registry.acr.admin_password
+}
+
+output "acr_server_url" {
+  description = "The server URL used to connect to the Container Registry"
+  sensitive   = true
+  value       = azurerm_container_registry.acr.login_server
+}
+
+output "acr_server_username" {
+  description = "The admin username used to connect to the Container Registry"
+  sensitive   = true
+  value       = azurerm_container_registry.acr.admin_username
+}

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -16,7 +16,7 @@ extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
     container: terraform-tools
-    project: infrastructure
+    projectName: infrastructure
     validateName: Validate Terraform
     validationSteps:
       - template: steps/terraform_format.yml@templates


### PR DESCRIPTION
- Add outputs for Container Registry - Looks like we need the admin account now that the pipeline is updating the container in the web app. For some reason, you can't have the managed identity do this.
- Add storage account for Cloud Shell