### PR TITLE
Change tooling VNET address space

### DIFF
--- a/infrastructure/network.tf
+++ b/infrastructure/network.tf
@@ -2,14 +2,14 @@ resource "azurerm_virtual_network" "tooling" {
   name                = "pins-vnet-${local.resource_suffix}"
   resource_group_name = azurerm_resource_group.tooling.name
   location            = azurerm_resource_group.tooling.location
-  address_space       = ["10.0.0.0/16"]
+  address_space       = ["10.10.0.0/24"]
 }
 
 resource "azurerm_subnet" "azure_agents" {
   name                 = "pins-snet-azure-agents-${local.resource_suffix}"
   resource_group_name  = azurerm_resource_group.tooling.name
   virtual_network_name = azurerm_virtual_network.tooling.name
-  address_prefixes     = ["10.0.0.0/24"]
+  address_prefixes     = ["10.10.0.0/24"]
 }
 
 resource "azurerm_virtual_network_peering" "dev_environment_peering" {


### PR DESCRIPTION
- Changes the tooling VNET address space to avoid address space overlap with PINS NI test environment. Re-deployment of self-hosted Azure DevOps agents used in the `infrastructure-environments` pipelines will be required.