### PR TITLE
Remove Front Door certificate pull policy from Key Vault

### DIFF
--- a/infrastructure/key-vault.tf
+++ b/infrastructure/key-vault.tf
@@ -36,15 +36,6 @@ resource "azurerm_key_vault_access_policy" "admins" {
   storage_permissions     = ["Get", "List", "Set"]
 }
 
-resource "azurerm_key_vault_access_policy" "frontdoor" {
-  key_vault_id = azurerm_key_vault.tooling_key_vault.id
-  object_id    = "c73a3f61-aa0a-4450-b3f8-303d72bf57a9" # Front Door service principal
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-
-  certificate_permissions = ["Get"]
-  secret_permissions      = ["Get"]
-}
-
 resource "random_password" "agents_admin_password" {
   length  = 20
   special = true


### PR DESCRIPTION
Remove certificate pull policy as Front Door requires key vault in same subscription