### PR TITLE
Add pipeline and script for build agent image cleanup

### DIFF
--- a/pipelines/build-agent-image-cleanup.yml
+++ b/pipelines/build-agent-image-cleanup.yml
@@ -3,8 +3,8 @@ trigger: none
 pr: none
 
 schedules:
-  - cron: "0 6 * * 1"
-    displayName: Monday 06:00 Weekly Cleanup
+  - cron: "0 6 * * 1-5"
+    displayName: Weekday 06:00 Cleanup
     branches:
       include:
       - main
@@ -41,6 +41,6 @@ stages:
                 -ResourceGroupName $(tooling_resource_group_name) `
                 -VMScaleSetName $(build_agent_scale_set_name)
               errorActionPreference: stop
-              FailOnStandardError: false
+              FailOnStandardError: true
               TargetAzurePs: latestVersion
             displayName: 'Cleanup Images'

--- a/pipelines/build-agent-image-cleanup.yml
+++ b/pipelines/build-agent-image-cleanup.yml
@@ -2,6 +2,13 @@ trigger: none
 
 pr: none
 
+schedules:
+  - cron: "0 6 * * 1"
+    displayName: Monday 06:00 Weekly Cleanup
+    branches:
+      include:
+      - main
+
 pool:
   vmImage: ubuntu-latest
 

--- a/pipelines/build-agent-image-cleanup.yml
+++ b/pipelines/build-agent-image-cleanup.yml
@@ -29,7 +29,7 @@ stages:
             inputs:
               ConnectedServiceNameARM: $(azureServiceConnection)
               ScriptType: 'filePath'
-              ScriptPath: $(Build.Repository.LocalPath/scripts/Remove-AzVmssUnusedImages.ps1
+              ScriptPath: $(Build.Repository.LocalPath)/scripts/Remove-AzVmssUnusedImages.ps1
               ScriptArguments: >
                 -ResourceGroupName $(tooling_resource_group_name) `
                 -VMScaleSetName $(build_agent_scale_set_name) `

--- a/pipelines/build-agent-image-cleanup.yml
+++ b/pipelines/build-agent-image-cleanup.yml
@@ -25,7 +25,7 @@ stages:
       - job: Cleanup
         displayName: Delete Unused Build Agent Images
         steps:
-          - task: PowerShell@5
+          - task: AzurePowerShell@5
             inputs:
               ConnectedServiceNameARM: $(azureServiceConnection)
               ScriptType: 'filePath'

--- a/pipelines/build-agent-image-cleanup.yml
+++ b/pipelines/build-agent-image-cleanup.yml
@@ -12,13 +12,6 @@ schedules:
 pool:
   vmImage: ubuntu-latest
 
-resources:
-  repositories:
-    - repository: templates
-      type: github
-      endpoint: Planning-Inspectorate
-      name: Planning-Inspectorate/common-pipeline-templates
-
 variables:
   azureServiceConnection: infrastructure-tooling
   subscriptionId: edb1ff78-90da-4901-a497-7e79f966f8e2

--- a/pipelines/build-agent-image-cleanup.yml
+++ b/pipelines/build-agent-image-cleanup.yml
@@ -32,8 +32,7 @@ stages:
               ScriptPath: $(Build.Repository.LocalPath)/scripts/Remove-AzVmssUnusedImages.ps1
               ScriptArguments: >
                 -ResourceGroupName $(tooling_resource_group_name) `
-                -VMScaleSetName $(build_agent_scale_set_name) `
-                -WhatIf
+                -VMScaleSetName $(build_agent_scale_set_name)
               errorActionPreference: stop
               FailOnStandardError: false
               TargetAzurePs: latestVersion

--- a/pipelines/build-agent-image-cleanup.yml
+++ b/pipelines/build-agent-image-cleanup.yml
@@ -1,0 +1,40 @@
+trigger: none
+
+pr: none
+
+pool:
+  vmImage: ubuntu-latest
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      endpoint: Planning-Inspectorate
+      name: Planning-Inspectorate/common-pipeline-templates
+
+variables:
+  azureServiceConnection: infrastructure-tooling
+  subscriptionId: edb1ff78-90da-4901-a497-7e79f966f8e2
+  tooling_resource_group_name: pins-rg-shared-tooling-uks
+  build_agent_scale_set_name: pins-vmss-shared-tooling-uks
+
+stages:
+  - stage: Cleanup
+    displayName: Cleanup
+    jobs:
+      - job: Cleanup
+        displayName: Delete Unused Build Agent Images
+        steps:
+          - task: PowerShell@5
+            inputs:
+              ConnectedServiceNameARM: $(azureServiceConnection)
+              ScriptType: 'filePath'
+              ScriptPath: $(Build.Repository.LocalPath/scripts/Remove-AzVmssUnusedImages.ps1
+              ScriptArguments: >
+                -ResourceGroupName $(tooling_resource_group_name) `
+                -VMScaleSetName $(build_agent_scale_set_name) `
+                -WhatIf
+              errorActionPreference: stop
+              FailOnStandardError: false
+              TargetAzurePs: latestVersion
+            displayName: 'Cleanup Images'

--- a/pipelines/build-azure-agents-image.yml
+++ b/pipelines/build-azure-agents-image.yml
@@ -38,20 +38,3 @@ stages:
             workingDirectory: $(Build.Repository.LocalPath)/packer/azure-agents
         workspace:
           clean: all
-  - stage: Cleanup
-    displayName: Cleanup
-    jobs:
-      - job: Cleanup
-        displayName: Remove Unused Build Agent Images
-        steps:
-          - task: PowerShell@2
-            inputs:
-              targetType: 'filePath'
-              filePath: $(Build.Repository.LocalPath/scripts/Remove-AzVmssUnusedImages.ps1
-              arguments: >
-                -ResourceGroupName $(tooling_resource_group_name)
-                -VMScaleSetName "pins-vmss-shared-tooling-uks"
-                -ExpireDays 1
-                -FailBuildOnError $false
-                -WhatIf
-            displayName: 'Cleanup Images'

--- a/pipelines/build-azure-agents-image.yml
+++ b/pipelines/build-azure-agents-image.yml
@@ -38,3 +38,20 @@ stages:
             workingDirectory: $(Build.Repository.LocalPath)/packer/azure-agents
         workspace:
           clean: all
+  - stage: Cleanup
+    displayName: Cleanup
+    jobs:
+      - job: Cleanup
+        displayName: Remove Unused Build Agent Images
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: $(Build.Repository.LocalPath/scripts/Remove-AzVmssUnusedImages.ps1
+              arguments: >
+                -ResourceGroupName $(tooling_resource_group_name)
+                -VMScaleSetName "pins-vmss-shared-tooling-uks"
+                -ExpireDays 1
+                -FailBuildOnError $false
+                -WhatIf
+            displayName: 'Cleanup Images'

--- a/scripts/Remove-AzVmssUnusedImages.ps1
+++ b/scripts/Remove-AzVmssUnusedImages.ps1
@@ -28,7 +28,7 @@ Try {
 
   # Get all Images in the resource group
   $Images = Get-AzImage -ResourceGroupName $ResourceGroupName
-  Write-Host "[$ScriptName] Found $($Images.Count) images"
+  Write-Host "[$ScriptName] Found $($Images.Count) images in resource group $ResourceGroupName"
 
   If ($Images.Count -lt 2) {
     Write-Host "[$ScriptName] Exiting: Nothing to do!"
@@ -54,12 +54,14 @@ Foreach ($Image in $Images) {
         $RemovedCount++
 
       } Else {
-        Write-Host "Removing image: $($Image.Name)"
-        Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name -Force
+        Write-Host "[$ScriptName] Removing image: $($Image.Name)"
+        Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name
+        Write-Host "[$ScriptName] Successfully removed image: $($Image.Name)"
         $RemovedCount++
       }
 
     } Catch {
+      Write-Host "[$ScriptName] Failed to remove image: $($Image.Name)"
       Write-Host "##vso[task.LogIssue type=warning;]$($_.Exception.Message)"
       Continue
     }

--- a/scripts/Remove-AzVmssUnusedImages.ps1
+++ b/scripts/Remove-AzVmssUnusedImages.ps1
@@ -30,7 +30,7 @@ Try {
   $Images = Get-AzImage -ResourceGroupName $ResourceGroupName
   Write-Host "[$ScriptName] Found $($Images.Count) images in resource group $ResourceGroupName"
 
-  If ($Images.Count -lt 2) {
+  If ($Images.Count -le 1) {
     Write-Host "[$ScriptName] Exiting: Nothing to do!"
     Exit 0
   }
@@ -46,7 +46,7 @@ Foreach ($Image in $Images) {
   $DateString = ($Image.Name).Split('-')[2]
   $ImageDate = [DateTime]::ParseExact($DateString, 'yyyyMMddHHmmss', $null)
 
-  # Remove any images not in-use by the VM Scale Set and >=24 hours old
+  # Remove any images not in-use by the VM Scale Set and >=12 hours old
   If (!($Image.Name -eq $ImageName) -and ($ImageDate -le $StartTime.AddHours(-$ExpireHours))) {
     Try {
       If ($WhatIf) {

--- a/scripts/Remove-AzVmssUnusedImages.ps1
+++ b/scripts/Remove-AzVmssUnusedImages.ps1
@@ -55,7 +55,7 @@ Foreach ($Image in $Images) {
 
       } Else {
         Write-Host "[$ScriptName] Removing image: $($Image.Name)"
-        Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name
+        Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name -Force
         Write-Host "[$ScriptName] Successfully removed image: $($Image.Name)"
         $RemovedCount++
       }

--- a/scripts/Remove-AzVmssUnusedImages.ps1
+++ b/scripts/Remove-AzVmssUnusedImages.ps1
@@ -6,11 +6,8 @@ Param(
   [Parameter(Mandatory=$true)]
   [String]$VMScaleSetName,
 
-  [Parameter(Mandatory=$true)]
-  [Int]$ExpireDays,
-
-  [Parameter(Mandatory=$true)]
-  [Bool]$FailBuildOnError,
+  [Parameter(Mandatory=$false)]
+  [Int]$ExpireDays = 1,
 
   [Parameter(Mandatory=$false)]
   [Switch]$WhatIf
@@ -33,7 +30,7 @@ Try {
 
 } Catch {
   Write-Host "##vso[task.LogIssue type=error;]$($_.Exception.Message)"
-  Exit [Int]$FailBuildOnError
+  Exit 1
 }
 
 # Get todays date for image date comparison
@@ -49,12 +46,12 @@ Foreach ($Image in $Images) {
   If ( !($Image.Name -eq $ImageName) -and ($ImageDate -le $Today.AddDays(-$ExpireDays)) ) {
     Try {
       If ($WhatIf) {
-        Write-Host "Removing image: $($Image.Name)"
-        Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name -Force
+        Write-Host "[WhatIf] Would have removed image: $($Image.Name)"
         $RemovedCount++
 
       } Else {
-        Write-Host "[WhatIf] Would have removed image: $($Image.Name)"
+        Write-Host "Removing image: $($Image.Name)"
+        Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name -Force
         $RemovedCount++
       }
 
@@ -66,10 +63,10 @@ Foreach ($Image in $Images) {
 }
 
 If ($WhatIf) {
-  Write-Host "Task complete: Removed $RemovedCount images"
+  Write-Host "[WhatIf] Would have removed $RemovedCount images"
 
 } Else {
-  Write-Host "[WhatIf] Would have removed $RemovedCount images"
+  Write-Host "Task complete: Removed $RemovedCount images"
 }
 
 Exit 0

--- a/scripts/Remove-AzVmssUnusedImages.ps1
+++ b/scripts/Remove-AzVmssUnusedImages.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding()]
+Param(
+  [Parameter(Mandatory=$true)]
+  [String]$ResourceGroupName,
+
+  [Parameter(Mandatory=$true)]
+  [String]$VMScaleSetName,
+
+  [Parameter(Mandatory=$true)]
+  [Int]$ExpireDays,
+
+  [Parameter(Mandatory=$true)]
+  [Bool]$FailBuildOnError,
+
+  [Parameter(Mandatory=$false)]
+  [Switch]$WhatIf
+)
+
+Try {
+  # Find the name of the image used by the VM Scale Set
+  $AgentPool = Get-AzVmss -ResourceGroupName $ResourceGroupName -VMScaleSetName $VMScaleSetName
+  $ImageName = ($AgentPool.VirtualMachineProfile.StorageProfile.ImageReference.Id).Split('/')[-1]
+  Write-Host "$VMScaleSetName is currently using image $ImageName"
+
+  # Get all Images in the resource group
+  $Images = Get-AzImage -ResourceGroupName $ResourceGroupName
+  Write-Host "Found $($Images.Count) images"
+
+  If ($Images.Count -lt 2) {
+    Write-Host "Nothing to do!"
+    Exit 0
+  }
+
+} Catch {
+  Write-Host "##vso[task.LogIssue type=error;]$($_.Exception.Message)"
+  Exit [Int]$FailBuildOnError
+}
+
+# Get todays date for image date comparison
+$Today = Get-Date
+
+Foreach ($Image in $Images) {
+  # Convert the datestamp in the image name to a DateTime object
+  $DateString = ($Image.Name).Split('-')[2]
+  $ImageDate = [DateTime]::ParseExact($DateString, 'yyyyMMddHHmmss', $null)
+
+  # Remove any images not in-use by the VM Scale Set and >=24 hours old
+  $RemovedCount = 0
+  If ( !($Image.Name -eq $ImageName) -and ($ImageDate -le $Today.AddDays(-$ExpireDays)) ) {
+    Try {
+      If ($WhatIf) {
+        Write-Host "Removing image: $($Image.Name)"
+        Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name -Force
+        $RemovedCount++
+
+      } Else {
+        Write-Host "[WhatIf] Would have removed image: $($Image.Name)"
+        $RemovedCount++
+      }
+
+    } Catch {
+      Write-Host "##vso[task.LogIssue type=warning;]$($_.Exception.Message)"
+      Continue
+    }
+  }
+}
+
+If ($WhatIf) {
+  Write-Host "Task complete: Removed $RemovedCount images"
+
+} Else {
+  Write-Host "[WhatIf] Would have removed $RemovedCount images"
+}
+
+Exit 0

--- a/scripts/Remove-AzVmssUnusedImages.ps1
+++ b/scripts/Remove-AzVmssUnusedImages.ps1
@@ -54,7 +54,7 @@ Foreach ($Image in $Images) {
         $RemovedCount++
 
       } Else {
-        Write-Host "[$ScriptName] Removing image: $($Image.Name)"
+        Write-Host "[$ScriptName] Removing image: $($Image.Name)`n"
         Remove-AzImage -ResourceGroupName $ResourceGroupName -ImageName $Image.Name -Force
         Write-Host "[$ScriptName] Successfully removed image: $($Image.Name)"
         $RemovedCount++


### PR DESCRIPTION
- Add a scripts directory with PowerShell script to identify and remove unused build agent images older than 12 hours.
- Add a new pipeline with schedule trigger to run the cleanup script every Monday at 06:00.