### PR TITLE
Add an agent pool for running tests

### DIFF
--- a/infrastructure/azure-devops-agent-pool.tf
+++ b/infrastructure/azure-devops-agent-pool.tf
@@ -2,7 +2,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "azure_devops_agent_pool" {
   #checkov:skip=CKV_AZURE_49: SSH key authentication not required
   #checkov:skip=CKV_AZURE_97: Encryption at host not required
   #checkov:skip=CKV_AZURE_149: Password authentication required
-  name                = "pins-vmss-${local.resource_suffix}"
+  for_each = local.agent_pools
+
+  name                = each.value["name"]
   resource_group_name = azurerm_resource_group.tooling.name
   location            = azurerm_resource_group.tooling.location
   sku                 = "Standard_D2ds_v5"
@@ -25,7 +27,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "azure_devops_agent_pool" {
 
   network_interface {
     enable_accelerated_networking = true
-    name                          = "pins-vnet-azure-agents-nic-${local.resource_suffix}"
+    name                          = each.value["nic_name"]
     primary                       = true
 
     ip_configuration {

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -1,4 +1,15 @@
 locals {
+  agent_pools = {
+    main = {
+      name     = "pins-vmss-${local.resource_suffix}"
+      nic_name = "pins-vnet-azure-agents-nic-${local.resource_suffix}"
+    }
+    test = {
+      name     = "pins-vmss-test-${local.resource_suffix}"
+      nic_name = "pins-vnet-azure-agents-nic-test-${local.resource_suffix}"
+    }
+  }
+
   resource_suffix = "shared-${var.environment}-${module.azure_region_primary.location_short}"
 
   tags = {

--- a/pipelines/build-azure-agents-image.yml
+++ b/pipelines/build-azure-agents-image.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.1 # refs/tags/release/1.1.0
+      ref: refs/tags/release/2.0.1
 
 variables:
   azureServiceConnection: infrastructure-tooling

--- a/pipelines/build-azure-agents-image.yml
+++ b/pipelines/build-azure-agents-image.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.1.0
+      ref: refs/tags/release/2.0.1 # refs/tags/release/1.1.0
 
 variables:
   azureServiceConnection: infrastructure-tooling

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -8,13 +8,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.1 # refs/tags/release/1.1.0
+      ref: refs/tags/release/2.0.1
 
 extends:
   template: stages/wrapper_cd.yml@templates
   parameters:
     deploymentStages:
       - name: Terraform Plan
+        container: terraform-tooling
         deploymentSteps:
           - template: ${{variables['Build.SourcesDirectory']}}/steps/terraform_plan.yml@templates
             parameters:
@@ -22,6 +23,7 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)/infrastructure
         isDeployment: false
       - name: Terraform Apply
+        artifact: terraform-plan
         dependsOn:
           - Terraform Plan
         deploymentSteps:

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -8,7 +8,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.1.0
+      ref: refs/tags/release/2.0.1 # refs/tags/release/1.1.0
 
 extends:
   template: stages/wrapper_cd.yml@templates

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -15,7 +15,6 @@ extends:
   parameters:
     deploymentStages:
       - name: Terraform Plan
-        container: terraform-tooling
         deploymentSteps:
           - template: ${{variables['Build.SourcesDirectory']}}/steps/terraform_plan.yml@templates
             parameters:

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -22,7 +22,6 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)/infrastructure
         isDeployment: false
       - name: Terraform Apply
-        artifact: terraform-plan
         dependsOn:
           - Terraform Plan
         deploymentSteps:

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -15,7 +15,6 @@ extends:
   parameters:
     deploymentStages:
       - name: Terraform Plan
-        authType: terraform
         deploymentSteps:
           - template: ${{variables['Build.SourcesDirectory']}}/steps/terraform_plan.yml@templates
             parameters:
@@ -23,7 +22,6 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)/infrastructure
         isDeployment: false
       - name: Terraform Apply
-        authType: terraform
         dependsOn:
           - Terraform Plan
         deploymentSteps:

--- a/pipelines/infra-cd.yml
+++ b/pipelines/infra-cd.yml
@@ -35,4 +35,3 @@ extends:
       - name: Tooling
     pool:
       vmImage: ubuntu-latest
-    project: infrastructure

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -9,7 +9,6 @@ resources:
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    projectName: infrastructure
     validateName: Validate Terraform
     validationSteps:
       - template: steps/terraform_format.yml@templates

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.1 # refs/tags/release/1.1.0
+      ref: refs/tags/release/2.0.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/pipelines/infra-ci.yml
+++ b/pipelines/infra-ci.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.1.0
+      ref: refs/tags/release/2.0.1 # refs/tags/release/1.1.0
 
 extends:
   template: stages/wrapper_ci.yml@templates


### PR DESCRIPTION
- Added a second Virtual Machine scale set to be used for running tests, thereby preventing deployments from being queued unnecessarily. 
- Updated pipelines to reflect changes in [common pipeline templates](https://github.com/Planning-Inspectorate/common-pipeline-templates). 