### PR TITLE
feature/as-5888-nvm-install-18-and-20

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -4,7 +4,7 @@ config {
 
 plugin "azurerm" {
   enabled = true
-  version = "0.15.0"
+  version = "0.18.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -4,7 +4,7 @@ config {
 
 plugin "azurerm" {
   enabled = true
-  version = "0.18.0"
+  version = "0.15.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 

--- a/packer/azure-agents/tools.sh
+++ b/packer/azure-agents/tools.sh
@@ -92,6 +92,7 @@ export NVM_DIR="/usr/local/nvm"
 export PATH="$PATH:$NVM_DIR"
 EOT
 
+nvm install 18
 nvm install 16
 nvm install 15
 nvm install 14

--- a/packer/azure-agents/tools.sh
+++ b/packer/azure-agents/tools.sh
@@ -92,6 +92,7 @@ export NVM_DIR="/usr/local/nvm"
 export PATH="$PATH:$NVM_DIR"
 EOT
 
+nvm install 20
 nvm install 18
 nvm install 16
 nvm install 15


### PR DESCRIPTION
Added: 
nvm install 18 - already in current LTS
nvm install 20 - will be in the LTS in October.


Upgraded tflint as version 0.15.0 to 0.18.0 is not supported on the current azurerm.
