### PR TITLE
fix: don't purge training acr images

### DIFF
--- a/pipelines/purge-acr-images.yml
+++ b/pipelines/purge-acr-images.yml
@@ -35,7 +35,7 @@ jobs:
           filters=()
 
           for repository in $repositories; do
-            filter="--filter \"$repository:^(?!^v\d|main|develop|dev|test|prod)\""
+            filter="--filter \"$repository:^(?!^v\d|main|develop|dev|test|prod|training|staging)\""
             filters+=( $filter )
           done
 


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Issue noticed where one of the apps couldn't find its image on `training`, because it had been purged!

## Useful information to review or test

<!--

Add any useful information that will help the reviewer test your changes.
This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
