### PR TITLE
fix: remove duplicate node version install (managed by nvm)

### DIFF
--- a/packer/azure-agents/tools.sh
+++ b/packer/azure-agents/tools.sh
@@ -74,11 +74,7 @@ python3.7 -m pip install -U checkov==2.2.94
 # TFLint
 curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
 
-# Node / NVM
-curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-
-sudo apt-get install nodejs
-
+# NVM
 sudo mkdir /usr/local/nvm && chmod -R 777 /usr/local/nvm
 sudo curl -o- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | NVM_DIR=/usr/local/nvm bash
 
@@ -92,6 +88,7 @@ export NVM_DIR="/usr/local/nvm"
 export PATH="$PATH:$NVM_DIR"
 EOT
 
+# Node versions
 nvm install 22
 nvm install 20
 nvm install 18


### PR DESCRIPTION
Remove duplicate install steps that installed versions of Node when NVM is already managing that.